### PR TITLE
Make Text span the entire width of the page

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,5 +1,5 @@
 {{ define "main_content" }}
-<main class="row-item small-full {{ if eq .Params.showsidebar true }}medium-two-thirds{{ end }}" {{ if (eq .Section "post") }}itemscope itemtype="http://schema.org/Blog"{{ end }}>
+<main class="row-item small-full" {{ if (eq .Section "post") }}itemscope itemtype="http://schema.org/Blog"{{ end }}>
   <article id="post-article" {{ if (eq .Section "post") }}itemprop="blogPost" itemscope itemtype="http://schema.org/BlogPosting"{{ else }}itemscope itemtype="http://schema.org/Article"{{ end }}{{ if .Params.tags }} itemref="keywords desc"{{ else }} itemref="desc"{{ end }}>
     <header id="page-header">
       <h1 itemprop="headline">{{ .Title }}</h1>


### PR DESCRIPTION
### Why
We want text to span the width of the page.

### What
Single.html still had a location checking for showSidebar and if that was set to true, then it set medium-two-thirds to the class value of the post which reduced the width of the text. This just removes that clause so that the text will span.

### How Tested
Verified using chrome debugger tools.

[Issue 3](https://github.com/mkpjapan/mkpjapan.github.io/issues/3)