### PR TITLE
Update the arrows to be closer to Figma

### DIFF
--- a/_includes/testimonials.html
+++ b/_includes/testimonials.html
@@ -10,6 +10,7 @@
         }
 
         .carousel-arrows {
+            position: relative;
             text-align: right;
             font-size: x-large;
             margin-top: -30px;
@@ -19,7 +20,7 @@
         }
 
         .carousel-arrows span:hover{
-            color: #{{site.data.template.color.mkpyellow}};
+            color: #{{site.data.template.color.mkpYellow}};
         }
 
         .slick-track {
@@ -53,8 +54,8 @@
         {% endfor %}
     </div>
     <div class="carousel-arrows">
-        <span class="prev fa-solid fa-chevron-circle-left"></span>
-        <span class="next fa-solid fa-chevron-circle-right"></span>
+        <span class="prev fa-regular fa-circle-left"></span>
+        <span class="prev fa-regular fa-circle-right"></span>
     </div>
 
     <script src="{{ '/static/js/jquery-1.11.0.js' | prepend: site.baseurl }}"></script>


### PR DESCRIPTION
## What
I updated the project to include font awesome which has a lot of arrows that would work. https://fontawesome.com/search?q=arrow&o=r&m=free&c=arrows

Unfortunately, the one in the figma involves arrows which cost money (pro) and layering so I couldn't go that far, but his one is a single glyph which mostly gets the job done with less pain in the css. Going to just recommend we keep this unless there's a reason to work on the css layering for better testimonial arrows. Note: This commit does not enable testimonials, but instead changes something on the page.

![image](https://github.com/mkpjapan/mkpjapan.github.io/assets/3760863/e6cbe579-c2e0-4e3c-9959-d6594423a47f)
