### PR TITLE
Add file to keep link working

### DIFF
--- a/agreements-com.md
+++ b/agreements-com.md
@@ -1,0 +1,10 @@
+---
+layout: single
+navbarClass: 'navbar-shrink'
+permalink: /agreements-com/
+note: === This is to restore the link that we use in the meetings ===
+
+title: The Mankind Project Japan Agreements
+---
+
+{% include agreements.md %}


### PR DESCRIPTION
I noticed that we have a /agreements-com/ page linked in several places, but we lost this page in this redesign. Originally, it was the Agreements page, but with the sidebar off.

We can either create this page, update all the links, or both. cc @fabien-lg .
