### PR TITLE
Fix redirect for email.

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,4 +1,5 @@
 ---
+# This exists to basically redirect any 404s back to the index.
 permalink: /404.html
 redirect_to:
  - /

--- a/404.html
+++ b/404.html
@@ -1,0 +1,5 @@
+---
+permalink: /404.html
+redirect_to:
+ - /
+---

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,6 @@ GEM
     unf (0.1.4)
       unf_ext
     unf_ext (0.0.8.2)
-    unf_ext (0.0.8.2-x64-mingw-ucrt)
     unicode-display_width (1.8.0)
     webrick (1.8.1)
 
@@ -274,6 +273,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-redirect-from
   webrick
 
 BUNDLED WITH

--- a/_includes/form.html
+++ b/_includes/form.html
@@ -24,5 +24,7 @@
     <div id="spinner" class="spinner">
         <div class="loader"></div>
     </div>
-    <iframe src="{{ s.join_url }}" width="100%" height="3200px" frameborder="0" marginheight="0" marginwidth="0" onload="document.getElementById('spinner').style.display='none';">Loading…</iframe>
+    <iframe src="{{ s.join_url }}" width="100%" height="3200px" frameborder="0" marginheight="0"
+            marginwidth="0" onload="document.getElementById('spinner').style.display='none';"
+            style="z-index: 2; transform-style: preserve-3d;">Loading…</iframe>
 </section>

--- a/form.md
+++ b/form.md
@@ -3,8 +3,6 @@ layout: single
 navbarClass: 'navbar-shrink'
 permalink: /form/
 title: The Mankind Project Japan Registration Form
-redirect_from:
- - /open-mens-group
 ---
 
 {% include form.html %}

--- a/open-mens-group.md
+++ b/open-mens-group.md
@@ -1,0 +1,5 @@
+---
+redirect_to:
+ - /form
+---
+

--- a/open-mens-group.md
+++ b/open-mens-group.md
@@ -1,5 +1,6 @@
 ---
+# This exists because the email link is https://www.mkpjapan.org/open-mens-group/&data=foo and the without a permalink,
+# the redirect_from tags don't appear to work. It's something to do with the additional query params.
 redirect_to:
  - /form
 ---
-


### PR DESCRIPTION
## What
The email redirect link is basically https://www.mkpjapan.org/open-mens-group/&data=foo and the jekyll redirect from package doesn't handle query strings at all. This still causes a failure without a perma-link. This is different from agreements-com which no one (that I know of) sends query params to. Adding a page and then using redirect_to form does the right things here.

Meta problem is that we can basically get 404s on the page because multiple pages were removed and we have no idea if they were linked to in other places. To fix this, I added a 404.html with a permalink tag which will just redirect all 404s to the index. This is fine since our page is actually quite small anyway and if they were looking for additional information, just going to the landing page is where they'll get everything now.

The spinner was showing above the iframe in /form and it looked ugly. Fix this by moving the iframe on a higher zband than the spinner.

## Why
Some links that we didn't expect are hitting 404s on the site still and we need to fix that to ensure that the site actually works.

## Testing
- [x] https://www.mkpjapan.org/open-mens-group/&data=foo goes to /form
- [x] https://www.mkpjapan.org/foo goes to index