### PR TITLE
Add the 'how long' question

### DIFF
--- a/_data/faqs.yml
+++ b/_data/faqs.yml
@@ -36,6 +36,10 @@
   a: >
      Yes, we **prioritize confidentiality** and create a safe and supportive environment for all participants. What is shared in the gatherings **stays within the group**.
 
+- q: How long are the meetings typically?
+  a: > 
+    Our meetings are scheduled from 7pm to 9pm Japan time. We often take a 5-10 minute break in the middle.
+
 - q: How can I contact you?
   a: >
     [Contact us](mailto:info@mkpjapan.org).


### PR DESCRIPTION
Q: How long are the meetings typically?
A: Our meetings are scheduled from 7pm to 9pm Japan time.  we often take a 5-10 minute break in the middle.

[discussion on slack](https://mkpjapan.slack.com/archives/C05U3EMV4F3/p1720662123914829)