### PR TITLE
Fix missing permalinks on resources pages causing 404s on GitHub Pages

### DIFF
--- a/resources/conflict-facilitation.md
+++ b/resources/conflict-facilitation.md
@@ -1,6 +1,7 @@
 ---
 layout: single
 title: Conflict Facilitation
+permalink: /resources/conflict-facilitation/
 ---
 
 # Conflict Facilitation

--- a/resources/conflict-resolution.md
+++ b/resources/conflict-resolution.md
@@ -1,6 +1,7 @@
 ---
 layout: single
 title: Conflict Resolution
+permalink: /resources/conflict-resolution/
 ---
 
 # Conflict Resolution


### PR DESCRIPTION
Jekyll defaults to flat .html output without explicit permalinks; add directory-style permalinks to match the links in resources/index.html.